### PR TITLE
Downgrade Newtonsoft.Json version to 6.0.8 #3

### DIFF
--- a/Abbyy.CloudSdk.Client/Abbyy.CloudSdk.Client.csproj
+++ b/Abbyy.CloudSdk.Client/Abbyy.CloudSdk.Client.csproj
@@ -21,13 +21,22 @@ This .NET library provides classes and methods to access ABBYY Cloud OCR SDK API
     <PackageTags>ocr icr recognition image pdf processing ABBYY</PackageTags>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.0'">
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472' OR '$(TargetFramework)' == 'net461' OR '$(TargetFramework)' == 'net45'">
     <Reference Include="System.Web" />
     <PackageReference Include="Microsoft.Net.Http" Version="2.2.29" />
+    <PackageReference Include="Newtonsoft.Json" Version="6.0.8" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
In order to improve overall compatibility the following versions of Newtonsoft.Json are used since this commit:

- .NET Standard 2.0: 11.0.1
- .NET Standard 1.3: 10.0.1
- .NET Standatd 1.0: 9.0.1
- .NET Framework 4.5, 4.6.1 and 4.7.2: 6.0.8